### PR TITLE
Allow proper PVC and PV usage

### DIFF
--- a/app/models/concerns/fog_extensions/kubevirt/pvc.rb
+++ b/app/models/concerns/fog_extensions/kubevirt/pvc.rb
@@ -1,0 +1,11 @@
+module FogExtensions
+  module Kubevirt
+    module Pvc
+      extend ActiveSupport::Concern
+
+      def id
+        name
+      end
+    end
+  end
+end

--- a/app/models/concerns/fog_extensions/kubevirt/volume.rb
+++ b/app/models/concerns/fog_extensions/kubevirt/volume.rb
@@ -1,0 +1,11 @@
+module FogExtensions
+  module Kubevirt
+    module Volume
+      extend ActiveSupport::Concern
+
+      def id
+        name
+      end
+    end
+  end
+end

--- a/app/views/compute_resources_vms/form/kubevirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/kubevirt/_volume.html.erb
@@ -1,15 +1,18 @@
-<%= select_f f, :name,
-                compute_resource.volume_claims,
-                :attributes,
-                :name,
-                { :include_blank => _("Create New Claim") },
-                :label => _('Persistent Volume Claim'),
-                :label_size => "col-md-2",
-                :disabled => !new_vm,
-                :onchange    => 'pvcSelected(this);',
-                :class => "col-md-2 pvc-name" %>
+<% if new_vm %>
+    <% claims = compute_resource.volume_claims %>
+    <%= select_f f, :id,
+                    claims,
+                    :attributes,
+                    :name,
+                    { :include_blank => _("Create New Claim") },
+                    :label => _('Persistent Volume Claim'),
+                    :label_size => "col-md-2",
+                    :disabled => !new_vm,
+                    :onchange    => 'pvcSelected(this);',
+                    :class => "col-md-2 pvc-name" %>
 
 <%= select_f f, :name, compute_resource.available_volumes, :attributes, :name,
                { }, :label => _('Persistent Volume'), :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2 pvc-selected-volume" %>
 
 <%= text_f f,:capacity, :label => _('Size (GB)'), :value => "", :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2 pvc-size" %>
+<% end %>

--- a/lib/foreman_kubevirt/engine.rb
+++ b/lib/foreman_kubevirt/engine.rb
@@ -36,8 +36,15 @@ module ForemanKubevirt
         require "fog/kubevirt"
         require "fog/compute/kubevirt/models/server"
         require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/server", __dir__)
-
         Fog::Compute::Kubevirt::Server.send(:include, ::FogExtensions::Kubevirt::Server)
+
+        require "fog/compute/kubevirt/models/volume"
+        require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/volume", __dir__)
+        Fog::Compute::Kubevirt::Volume.send(:include, ::FogExtensions::Kubevirt::Volume)
+
+        require "fog/compute/kubevirt/models/pvc"
+        require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/pvc", __dir__)
+        Fog::Compute::Kubevirt::Pvc.send(:include, ::FogExtensions::Kubevirt::Pvc)
       rescue StandardError => e
         Rails.logger.warn "Foreman-Kubevirt: skipping engine hook (#{e})"
       end


### PR DESCRIPTION
In order to allow differentiating between using an existing claim to
creating a new claim on PV, we need different properties for each to
act is the identified symbol for 'volume_attributes'.