### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 0.1.1 / 2019-04-24
+
+* Raise error in case of booting from volume and from image (#81)
+* Update references to foreman org (#83)
+* Fix bootable flag (#80)
+* Fix Pod network element (#79)
+* Add exception in case capacity is empty
+* Support compute profiles (#76)
+* Add link to plugin documentation (#77)
+
 ### 0.1.0 / 2019-04-17
 
 * Initial release of `foreman_kubevirt` plugin. It provides common `kubevirt`

--- a/lib/foreman_kubevirt/version.rb
+++ b/lib/foreman_kubevirt/version.rb
@@ -1,3 +1,3 @@
 module ForemanKubevirt
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end


### PR DESCRIPTION
* Raise error in case of booting from volume and from image (#81)
* Update references to foreman org (#83)
* Fix bootable flag (#80)
* Fix Pod network element (#79)
* Add exception in case capacity is empty
* Support compute profiles (#76)
* Add link to plugin documentation (#77)