### PR TITLE
Clear assets precompile error

### DIFF
--- a/app/assets/javascripts/foreman_kubevirt/kubevirt.js
+++ b/app/assets/javascripts/foreman_kubevirt/kubevirt.js
@@ -1,5 +1,5 @@
 bootableRadio = function (item) {
-  const disabled = $('[id$=_bootable_true]:disabled:checked:visible');
+  disabled = $('[id$=_bootable_true]:disabled:checked:visible');
 
   $('[id$=_bootable_true]').prop('checked', false);
   if (disabled.length > 0) {
@@ -10,8 +10,8 @@ bootableRadio = function (item) {
 }
 
 cniProviderSelected = function (item) {
-  const selected = $(item).val().toLowerCase();
-  const networks = $(item).parentsUntil('.fields').parent().find('#networks');
+  selected = $(item).val().toLowerCase();
+  networks = $(item).parentsUntil('.fields').parent().find('#networks');
 
   if (selected == "pod") {
     disableDropdown(networks);


### PR DESCRIPTION
Running the following command:
`rake 'plugin:assets:precompile[foreman_kubevirt]' RAILS_ENV=production`

fails with:
```
Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax,
harmony mode must be enabled with Uglifier.new(:harmony => true).
```
Removing the constant didn't change much on the code itself.