### PR TITLE
Fixes #26656 - Fix memory issues

### DIFF
--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -145,7 +145,7 @@ module ForemanKubevirt
       begin
         client.vms.create(:vm_name     => options[:name],
                           :cpus        => options[:cpu_cores].to_i,
-                          :memory_size => options[:memory].to_i / 2**20,
+                          :memory_size => convert_memory(options[:memory] + "b", :m).to_s,
                           :volumes     => volumes,
                           # :cloudinit   => init,
                           :networks    => networks,
@@ -177,7 +177,7 @@ module ForemanKubevirt
     # return 'false'
     def vm_instance_defaults
       {
-        :memory    => 1024.megabytes,
+        :memory    => 1024.megabytes.to_s,
         :cpu_cores => '1'
       }
     end
@@ -258,6 +258,14 @@ module ForemanKubevirt
 
     def max_memory
       64.gigabytes
+    end
+
+    # Converts a given memory to bytes
+    #
+    # @param memory - The memory of the VM to convert
+    #
+    def convert_memory_to_bytes(memory)
+      convert_memory(memory, :b)
     end
 
     protected
@@ -427,6 +435,10 @@ module ForemanKubevirt
       end
 
       [interfaces, networks]
+    end
+
+    def convert_memory(memory, unit)
+      ::Fog::Kubevirt::Compute::Shared::UnitConverter.convert(memory, unit).to_i
     end
   end
 end

--- a/app/views/compute_resources_vms/index/_kubevirt.html.erb
+++ b/app/views/compute_resources_vms/index/_kubevirt.html.erb
@@ -12,7 +12,7 @@
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :auth_action => 'view', :authorizer => authorizer) %></td>
       <td><%= vm.cpu_cores %></td>
-      <td><%= vm.memory %></td>
+      <td><%= number_to_human_size @compute_resource.convert_memory_to_bytes(vm.memory) %></td>
       <td>
         <span <%= vm_power_class(vm.ready?) %>>
           <%= vm_state(vm) %></span>

--- a/app/views/compute_resources_vms/show/_kubevirt.html.erb
+++ b/app/views/compute_resources_vms/show/_kubevirt.html.erb
@@ -20,8 +20,7 @@
       </tr>
       <tr>
         <td><%= _('Memory') %></td>
-        <td><%= number_to_human_size @vm.memory %>
-        </td>
+        <td><%= number_to_human_size @compute_resource.convert_memory_to_bytes(@vm.memory) %></td>
       </tr>
       <tr>
         <td><%= _('Namespace') %></td>

--- a/test/unit/foreman_kubevirt_test.rb
+++ b/test/unit/foreman_kubevirt_test.rb
@@ -132,7 +132,7 @@ class ForemanKubevirtTest < ActiveSupport::TestCase
 
   test "create_vm without CPU should pass" do
     vm_args = NETWORK_BASED_VM_ARGS.deep_dup
-    vm_args["cpu_cores"] = nil
+    vm_args.delete("cpu_cores")
     Fog.mock!
     compute_resource = new_kubevirt_vcr
     server = compute_resource.create_vm(vm_args)
@@ -143,12 +143,22 @@ class ForemanKubevirtTest < ActiveSupport::TestCase
 
   test "create_vm without memory should pass" do
     vm_args = NETWORK_BASED_VM_ARGS.deep_dup
-    vm_args["memory"] = nil
+    vm_args.delete("memory")
     Fog.mock!
     compute_resource = new_kubevirt_vcr
     server = compute_resource.create_vm(vm_args)
 
     # verify default memory value is set
     assert_equal "1024M", server.memory
+  end
+
+  test "converts memory to byte" do
+    Fog.mock!
+    compute_resource = new_kubevirt_vcr
+    assert_equal 1.gigabytes, compute_resource.convert_memory_to_bytes("1Gi")
+    assert_equal 1.megabytes, compute_resource.convert_memory_to_bytes("1Mi")
+    assert_equal 1_000_000_000, compute_resource.convert_memory_to_bytes("1G")
+    assert_equal 1_000_000, compute_resource.convert_memory_to_bytes("1M")
+    assert_equal 0, compute_resource.convert_memory_to_bytes("0b")
   end
 end


### PR DESCRIPTION
The PR fixes few memory issues:
* The memory default value should be a string (same as passed in
arguments)
* Memory default value should be provided as string (this is the
expected format in the VM arguments)
* Tests should be updated no to provide memory or CPU in order to rely
on the defaults
* Memory should be shown in a normalized way in the UI
* When creating VM, the memory should be converted to MB, while before
this PR it was considered to be MiB which lead to a lower amount of
memory than expected.