### PR TITLE
Fix #26784 - Create VM with image only should pass

### DIFF
--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -312,7 +312,7 @@ module ForemanKubevirt
 
     def verify_booting_from_image_is_possible(volumes)
       raise ::Foreman::Exception.new N_('It is not possible to set a bootable volume and image based provisioning.') if
-        volumes.any? { |_, v| v[:bootable] == "true" }
+        volumes&.any? { |_, v| v[:bootable] == "true" }
     end
 
     def add_volume_for_image_provision(options)

--- a/test/unit/foreman_kubevirt_test.rb
+++ b/test/unit/foreman_kubevirt_test.rb
@@ -73,6 +73,17 @@ class ForemanKubevirtTest < ActiveSupport::TestCase
     assert_equal 1, server.interfaces.count
   end
 
+  test "create_vm image based without additional volumes should pass" do
+    vm_args = IMAGE_BASED_VM_ARGS.deep_dup
+    vm_args.delete("volumes_attributes")
+
+    Fog.mock!
+    compute_resource = new_kubevirt_vcr
+    server = compute_resource.create_vm(vm_args)
+
+    assert_equal "olive-kempter.example.com", server.name
+  end
+
   test "should fail when creating a VM with_bootable flag and image based" do
     vm_args = IMAGE_BASED_VM_ARGS.deep_dup
     vm_args["volumes_attributes"]["0"]["bootable"] = "true"


### PR DESCRIPTION
Creating a host without additional volumes doesn't pass any value for
volumes_attributes, therefore we should assume it may be nil.