### PR TITLE
Use fog-kubevirt 1.3.0

### DIFF
--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -142,12 +142,13 @@ module ForemanKubevirt
       volumes = create_volumes_for_vm(options)
       interfaces, networks = create_network_devices_for_vm(options, volumes)
       # Add clound init user data
-      user_data = options[:user_data].present? ? { "userData" => options[:user_data] } : nil
+      user_data = { "userData" => options[:user_data] } if options[:user_data].present?
 
       begin
         client.vms.create(:vm_name     => options[:name],
                           :cpus        => options[:cpu_cores].to_i,
-                          :memory_size => convert_memory(options[:memory] + "b", :m).to_s,
+                          :memory_size => convert_memory(options[:memory] + "b", :mi).to_s,
+                          :memory_unit => "Mi",
                           :volumes     => volumes,
                           :cloudinit   => user_data,
                           :networks    => networks,
@@ -440,7 +441,7 @@ module ForemanKubevirt
     end
 
     def convert_memory(memory, unit)
-      ::Fog::Kubevirt::Compute::Shared::UnitConverter.convert(memory, unit).to_i
+      ::Fog::Kubevirt::Utils::UnitConverter.convert(memory, unit).to_i
     end
   end
 end

--- a/foreman_kubevirt.gemspec
+++ b/foreman_kubevirt.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '~> 12.3')
   s.add_development_dependency('rubocop', '~> 0.64')
 
-  s.add_dependency('fog-kubevirt', '~>1.2')
+  s.add_dependency('fog-kubevirt', '~>1.3')
 end

--- a/lib/foreman_kubevirt/engine.rb
+++ b/lib/foreman_kubevirt/engine.rb
@@ -44,6 +44,7 @@ module ForemanKubevirt
     config.to_prepare do
       begin
         require "fog/kubevirt"
+        require "fog/kubevirt/compute/utils/unit_converter"
         require "fog/kubevirt/compute/models/server"
         require File.expand_path("../../app/models/concerns/fog_extensions/kubevirt/server", __dir__)
 


### PR DESCRIPTION
By upgrading to fog-kubevirt-1.3.0, the memory for the created vm can be
specified with its units, so we'll get the exact desired memory.