### PR TITLE
Fixes #27494 - Fix validation and test_connection

### DIFF
--- a/app/views/compute_resources/form/_kubevirt.html.erb
+++ b/app/views/compute_resources/form/_kubevirt.html.erb
@@ -5,7 +5,9 @@
               :keep_value => true, :unset => unset_password?,
               :help_block => _("e.g. eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9..."),
               :help_inline => documentation_button('/foreman_kubevirt/0.x/index.html#4.1SettingComputeResourceTokenandX509CAvalues',
-                                                   root_url: 'https://theforeman.org/plugins') %>
+              :root_url => 'https://theforeman.org/plugins'),
+              :id => "compute_resource_password"
+%>
 
 <%= textarea_f f, :ca_cert, :label => _("X509 Certification Authorities"),
   :placeholder => _("Optionally provide a CA, or a correctly ordered CA chain or a path to a file. If left blank - insecure.") %>


### PR DESCRIPTION
There were several issues with the token: 
1. The validation should run in test connection and when submitting the form, and they didn't
2. test connection button  didn't work properly, the token got disabled after "Test connection" because the JS function searched for compute_resource_password but in the erb file we sent the id as compute_resource_token