### PR TITLE
Remove environment from the host factory

### DIFF
--- a/test/factories/host_factories.rb
+++ b/test/factories/host_factories.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     root_pass { "$5$pzp5IoYXH9WQT6Ks$fk1OzfJAK1" }
     architecture_id { 1 }
     operatingsystem_id { 3 }
-    environment_id { 3 }
     ptable_id { 91 }
     medium_id { 13 }
     build { true }


### PR DESCRIPTION
The environment was extracted to foreman_puppet and isn't relevant for the test.