### PR TITLE
Keep KubeVirt bootable volumes consistent

### DIFF
--- a/app/models/concerns/fog_extensions/kubevirt/volume.rb
+++ b/app/models/concerns/fog_extensions/kubevirt/volume.rb
@@ -3,7 +3,7 @@ module FogExtensions
     module Volume
       extend ActiveSupport::Concern
       def bootable
-        boot_order == 1
+        !boot_order.nil?
       end
 
       def id

--- a/app/models/foreman_kubevirt/kubevirt.rb
+++ b/app/models/foreman_kubevirt/kubevirt.rb
@@ -128,8 +128,12 @@ module ForemanKubevirt
       return unless new_volume_errors.empty?
       capacity = attrs.delete(:capacity)
       args = {capacity: capacity}.merge(attrs)
+      boot_order = args[:boot_order] || args['boot_order']
+      bootable = args[:bootable] || args['bootable']
       vol = Fog::Kubevirt::Compute::Volume.new(args)
-      vol.boot_order = 1 if args[:bootable] == "on" || args[:bootable] == "true"
+      if boot_order.blank? && ["on", "true"].include?(bootable)
+        vol.boot_order = 1
+      end
       vol
     end
 
@@ -260,7 +264,11 @@ module ForemanKubevirt
           nil
         end
       end.compact
-      vm_attrs[:volumes_attributes] = Hash[volumes.each_with_index.map { |volume, idx| [idx.to_s, volume.attributes] }]
+      vm_attrs[:volumes_attributes] = Hash[volumes.each_with_index.map do |volume, idx|
+        attrs = volume.attributes.with_indifferent_access
+        attrs[:bootable] = "true" if volume.bootable
+        [idx.to_s, attrs]
+      end]
 
       vm_attrs
     end
@@ -441,14 +449,28 @@ module ForemanKubevirt
       end
     end
 
-    def create_vm_volume(pvc_name, capacity, storage_class, bootable)
+    def create_vm_volume(pvc_name, capacity, storage_class, boot_order)
       create_new_pvc(pvc_name, capacity, storage_class)
 
       volume = Fog::Kubevirt::Compute::Volume.new
       volume.type = 'persistentVolumeClaim'
       volume.info = pvc_name
-      volume.boot_order = 1 if bootable == "true"
+      volume.boot_order = boot_order if boot_order.present?
       volume
+    end
+
+    def bootable_volume?(volume_attributes)
+      volume_attributes[:bootable] == "true"
+    end
+
+    def provisioning_interface_present?(options)
+      options.fetch(:interfaces_attributes, {}).values.any? { |iface| iface[:provision] == true }
+    end
+
+    def boot_order_for_pvc(options, volume_attributes, image_provision)
+      return nil if image_provision || !bootable_volume?(volume_attributes)
+
+      provisioning_interface_present?(options) ? 2 : 1
     end
 
     def add_volumes_based_on_pvcs(options, image_provision)
@@ -462,14 +484,14 @@ module ForemanKubevirt
       vm_name = options[:name].gsub(/[._]+/, '-')
       volumes_attributes.each_with_index do |(_, v), index|
         # skip if this is a boot volume for image provisioning
-        next if image_provision && v[:bootable]
+        next if image_provision && bootable_volume?(v)
         # Add PVC as volumes to the virtual machine
         pvc_name = vm_name + "-claim-" + (index + 1).to_s
         capacity = v[:capacity]
         storage_class = v[:storage_class]
-        bootable = v[:bootable] && !image_provision
+        boot_order = boot_order_for_pvc(options, v, image_provision)
 
-        volume = create_vm_volume(pvc_name, capacity, storage_class, bootable)
+        volume = create_vm_volume(pvc_name, capacity, storage_class, boot_order)
         volumes << volume
       end
 

--- a/test/models/compute_resources/kubevirt_test.rb
+++ b/test/models/compute_resources/kubevirt_test.rb
@@ -104,6 +104,75 @@ class ForemanKubevirtTest < ActiveSupport::TestCase
       record.create_vm({ :name => "test", :provision_method => 'image', :image_id => "default/template", :volumes_attributes => { "0" => { :capacity => "10", :bootable => "true" } }, :interfaces_attributes => { "0" => { "cni_provider" => "multus", "network" => "default/network" } } })
     end
 
+    test "keeps provisioning NIC first and assigns bootable PVC disk second" do
+      record = new_kubevirt_vcr
+      client = mocked_client
+      record.stubs(:client).returns(client)
+
+      client.vms.expects(:create).with do |args|
+        assert_equal 1, args[:volumes].length
+        assert_equal 2, args[:volumes].first.boot_order
+        assert_equal 1, args[:interfaces].length
+        assert_equal 1, args[:interfaces].first[:bootOrder]
+      end
+
+      record.create_vm({
+        :name => "test",
+        :volumes_attributes => { "0" => { :capacity => "10", :storage_class => "local", :bootable => "true" } },
+        :interfaces_attributes => { "0" => { "cni_provider" => "multus", "network" => "default/network", :provision => true } },
+      })
+    end
+
+    test "assigns bootable PVC disk first when there is no provisioning NIC" do
+      record = new_kubevirt_vcr
+      client = mocked_client
+      record.stubs(:client).returns(client)
+
+      client.vms.expects(:create).with do |args|
+        assert_equal 1, args[:volumes].length
+        assert_equal 1, args[:volumes].first.boot_order
+        assert_equal 1, args[:interfaces].length
+        assert_nil args[:interfaces].first[:bootOrder]
+      end
+
+      record.create_vm({
+        :name => "test",
+        :volumes_attributes => { "0" => { :capacity => "10", :storage_class => "local", :bootable => "true" } },
+        :interfaces_attributes => { "0" => { "cni_provider" => "multus", "network" => "default/network" } },
+      })
+    end
+
+    test "serializes boot ordered PVCs as bootable for round trip" do
+      record = new_kubevirt_vcr
+      client = mocked_client
+      record.stubs(:client).returns(client)
+
+      volume = Fog::Kubevirt::Compute::Volume.new
+      volume.type = 'persistentVolumeClaim'
+      volume.info = 'test-claim'
+      volume.boot_order = 2
+
+      vm = stub(name: "test", volumes: [volume])
+      client.pvcs.stubs(:get).with('test-claim').returns(stub)
+
+      vm_attrs = record.send(:set_vm_volumes_attributes, vm, {})
+      attrs = vm_attrs[:volumes_attributes]["0"].with_indifferent_access
+
+      assert_equal 2, attrs[:boot_order]
+      assert_equal "true", attrs[:bootable]
+    end
+
+    test "preserves explicit boot order when rebuilding a bootable volume" do
+      record = new_kubevirt_vcr
+      client = mocked_client
+      record.stubs(:client).returns(client)
+
+      volume = record.new_volume({ :capacity => "10", :storage_class => "local", :bootable => "true", :boot_order => 2 })
+
+      assert_equal 2, volume.boot_order
+      assert volume.bootable
+    end
+
     test "raises an error for image based provisioning with only an extra data volume" do
       record = new_kubevirt_vcr
       client = mocked_client


### PR DESCRIPTION
Derive PVC boot order from the provisioning context so PXE installs keep the NIC first while disk-only boots still mark the selected volume bootable.

Preserve bootable volume semantics when serializing and rebuilding VM attributes so edit and round-trip paths stay aligned with the create flow. This fixes the original mismatch where the create path could assign a bootable PVC `boot_order` of 2 while the read path only treated `boot_order == 1` as bootable.